### PR TITLE
new feature - screen jobs.

### DIFF
--- a/database.py
+++ b/database.py
@@ -1,20 +1,21 @@
 from sqlalchemy import create_engine
+from sqlalchemy.engine.reflection import Inspector
 import pandas as pd
 import agent
 import sqlite3
 import gsheet.api as gs
 
 engine = None
+inspector = None
 gs_engine = None
 SQL_DB_NAME = 'sqlite:///jobs.db'
 GSHEET_CONFIG = {'wkbid':'1JiB-ofvyimIOZ9vVxF22xIyXybIP5FCyo6N_x-pvmCs',
+                 'openings':'openings!A2:H',
+                 'screened':'screened!A2:I',
+                 'tags':'tags!A2:D',
                    }
 
-table_names = [
-    'source',
-    'job',
-    'match',
-]
+table_names = []
 
 sources = [
     {'name':'MyCareerFutures','url':'https://www.mycareersfuture.sg/'},
@@ -23,11 +24,18 @@ sources = [
 #sqlite db
 
 def load(loadsheet=True):
-    global engine, SQL_DB_NAME
+    global engine, SQL_DB_NAME, table_names
     if engine is None:
         engine = create_engine(SQL_DB_NAME, echo=False)
+        load_inspector()
+
     if loadsheet:
         load_gsheet()
+
+def load_inspector():
+    global inspector
+    inspector = Inspector.from_engine(engine)
+    table_names = inspector.get_table_names()
 
 def setup():
     'this script is used to initialize the database for the first time'
@@ -39,6 +47,11 @@ def setup():
     jobs = pd.read_csv(agent.files['job_openings'])
     add_jobs(jobs,append=False)
 
+def table_exists(tableName):
+    global inspector, table_names
+    load_inspector()
+    return tableName in table_names
+
 def add_jobs(jobs,append=True):
     global engine
     if append:
@@ -46,6 +59,18 @@ def add_jobs(jobs,append=True):
     else:
         ifex = 'replace'
     jobs.to_sql('job', con=engine, if_exists=ifex, index=False)
+
+def update_match(new_matches,update=True):
+    global engine
+    match = get_table('match')
+    if match is None:
+        match = new_matches
+    else:
+        new_matches.set_index('jobid',inplace=True)
+        match.set_index('jobid',inplace=True)
+        match.update(new_matches)
+        match.reset_index(inplace=True)
+    match.to_sql('match', con=engine, if_exists='replace', index=False)
 
 def get_sources():
     global engine
@@ -61,6 +86,13 @@ def get_tags():
     tags = pd.read_sql_table('tag',con=engine)
     return tags
 
+def get_table(tableName):
+    if table_exists(tableName):
+        tbl = pd.read_sql_table(tableName,con=engine)
+    else:
+        tbl = None
+    return tbl
+
 #gsheet
 
 def load_gsheet():
@@ -68,19 +100,21 @@ def load_gsheet():
     if gs_engine is None:
         gs_engine = gs.SheetsEngine()
 
-def post_jobs_to_gsheet(jobs):
-    wkbid = GSHEET_CONFIG['wkbid']
-    rngid = 'openings!B2:H'
-
+def post_to_gsheet(df,rng_code):
     #values is a 2D list [[]]
-    values = jobs.values.astype('str').tolist()
+    wkbid = GSHEET_CONFIG['wkbid']
+    rngid = GSHEET_CONFIG[rng_code]
+    values = df.values.astype('str').tolist()
     gs_engine.clear_rangevalues(wkbid,rngid)
     #write values - this method writes everything as a string
     gs_engine.set_rangevalues(wkbid,rngid,values)
 
+def post_jobs_to_gsheet(df):
+    post_to_gsheet(df,'openings')
+
 def update_tags():
     wkbid = GSHEET_CONFIG['wkbid']
-    rngid = 'tags!A2:D'
+    rngid = GSHEET_CONFIG['tags']
     taglist = gs_engine.get_rangevalues(wkbid,rngid)
-    tags = pd.DataFrame(taglist, columns=['tag', 'tag_type','match_yn','score'])
+    tags = pd.DataFrame(taglist, columns=['tag', 'tag_type','group','score'])
     tags.to_sql('tag',con=engine,if_exists='replace',index=False)

--- a/match.py
+++ b/match.py
@@ -2,11 +2,19 @@ from agent import JobSearchWebsite
 import database as db
 import text as tx
 import pandas as pd
+import datetime as dt
+import report
 
 # load an instance of JobSearchWebsite --> jobsite
 jobsite = None
 jobs = None
 titles = None
+matches = None
+screened = None
+
+FILTER_SETTINGS = {
+    'age_weeks':3,
+}
 
 def load_jobsite():
     global jobsite, jobs
@@ -36,12 +44,78 @@ def get_tag_counts(tag_type,norm=False):
         counts = counts/sum(counts)
     return counts
 
-def update_tags():
-    global titles
+def keyword_tags():
     db.update_tags()
     tags = db.get_tags()
+    return tags
+
+def extracted_tags():
+    tags = keyword_tags()
     tx.load_tags(tags)
     jobs = db.get_jobs()
     tx.load_jobs(jobs)
     tx.run_jobtitle_report()
     titles = tx.jobs['titles'].copy()
+    return titles
+
+def screen_jobs():
+    ''' screens jobs based on matching keyword tags.
+    The process is divided into two general steps - scoring and filtering and 5 sub-processes
+    - cleanup title and extract tags, score the clean title from extracted tags.
+    The screened table drops the reject scores and filters for current applications based on posted_date.
+    The inputs are the job and tag tables and there are two outputs
+    - an updated sqlite table ‘match’ and the screened jobs posted to gsheet.'''
+
+    #01 cleanup title, extract tags, score title
+    #02 store the match_auto score in the sqlite match table
+    update_matches()
+    #03 drop the relected positions, filter for most recent posts <=3 weeks
+    #04 push update to gsheet
+    update_screened()
+
+def score_positions():
+    ''' scores positions using text.py to cleanup title, extract tags
+    and compute score from extracted tags
+    '''
+    global jobs, titles
+    tags = keyword_tags()
+    tx.load_jobs(jobs)
+    tx.load_tags(tags)
+    tx.run_jobtitle_report()
+    titles = tx.jobs['titles'].copy()
+
+def update_matches():
+    '''updates the match table from the titles table by dropping fields
+    '''
+    global titles, matches
+    score_positions()
+    #fields to keep : jobid, clean_title, match_auto
+    fields = ['jobid','clean_title','match_auto']
+    matches = titles[fields].copy()
+    db.update_match(matches)
+
+def add_weeks(df):
+    df['date'] = df.apply(lambda x: dt.datetime.strptime(
+        x.posted_date, '%Y-%m-%d').date(),axis=1)
+    del df['posted_date']
+    df.rename(columns={'date': 'posted_date'}, inplace=True)
+    df['monday'] = report.get_mondays(df['posted_date'])
+    monday = report.get_monday(dt.datetime.today().date())
+    df['week'] = df.apply(lambda x: int((monday - x.monday).days / 7), axis=1)
+    del df['monday']
+    return df
+
+def update_screened():
+    ''' drops the rejected positions and filters for recent based on posted_date
+    '''
+    global titles, jobs, screened
+    weeks = FILTER_SETTINGS['age_weeks']
+    fields = ['match_auto','clean_title','company_name','salaryHigh','week',
+              'posted_date','position_title','urlid','jobid']
+    screened = jobs.merge(titles[['jobid', 'clean_title', 'match_auto']], on='jobid')
+    screened = add_weeks(screened)
+    recent = screened[screened['week'] <= weeks]
+    keep = recent[recent.match_auto != -1]
+    screened = keep[fields].sort_values(['week', 'match_auto'], ascending=(True, False))
+    #post to gsheet
+    db.post_to_gsheet(screened,'screened')

--- a/report.py
+++ b/report.py
@@ -11,6 +11,7 @@ import re
 import datetime as dt
 import pandas as pd
 import database as db
+import match
 
 # load an instance of JobSearchWebsite --> jobsite
 jobsite = None
@@ -77,10 +78,19 @@ def update_jobs_report(from_file=False):
         jobsite.set_report_parameters(salaryLevels,categories)
         jobsite.update_jobRecords()
         jobs = jobsite.jobs['records']
+        match.load_db()
+        screen_jobs()
 
     #02 post the results to the google spreadsheet
     db.post_jobs_to_gsheet(jobs)
     print('jobs report updated.')
+
+def screen_jobs():
+    match.load_db()
+    match.screen_jobs()
+
+def get_monday(dateValue):
+    return dateValue-dt.timedelta(days=dateValue.weekday())
 
 def get_mondays(date_series):
     return date_series.apply(lambda x:x-dt.timedelta(days=x.weekday()))
@@ -105,6 +115,8 @@ def autorun():
             update_jobs_report()
         elif process_name == 'update_jobRecords':
             update_jobRecords()
+        elif process_name == 'screen_jobs':
+            screen_jobs()
     else:
         print('no report specified')
 


### PR DESCRIPTION
Documentation updated in wiki [screen_jobs()](https://github.com/taylorhickem/jobsearch/wiki/screen_jobs()).

Screens jobs based on matching keyword tags. The process is divided into two general steps - scoring and filtering and 5 sub-processes : scores job positions based on title by extracting tags, uses customized user defined tags with match scores +1, -1.  output posted to gsheet. screened list of openings has new added match score.

1. text.run_jobtitle_report() cleanup title and extract tags
2. text.score_title() score the clean title from extracted tags.
3. The screened table drops the reject scores and filters for current applications based on posted_date by week
4. The inputs are the job and tag tables and there are two outputs an updated sqlite table ‘match’
5. The screened jobs are then posted to gsheet.